### PR TITLE
companion object of `Uid` extends function

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ case class Uid(value: Long) extends ClaimValue {
   override val jsValue: JsValue = JsNumber(value)
 }
 
-object Uid extends ClaimField {
+object Uid extends (Long => Uid) with ClaimField {
 
   // A function that attempts to construct our claim from a json value
   override def attemptApply(value: JsValue): Option[ClaimValue] =


### PR DESCRIPTION
If `Uid` companion object was not defined, Play would generate it extending a function. When you (partially) override the companion object you should extend the function to retain original behavior.
