### PR TITLE
Add Support For Base64 Encoded Secret Key

### DIFF
--- a/src/main/scala/io/igl/jwt/DecodedJwt.scala
+++ b/src/main/scala/io/igl/jwt/DecodedJwt.scala
@@ -122,7 +122,7 @@ object DecodedJwt {
   }
 
   /**
-    * This method use the underlying method {@link #validateEncodedJwtWithEncodedSecret(String,Array[Byte],Algorithm,Set[HeaderField],Set[ClaimField],Set[String],Set[String],Option[Iss],Option[Aud], Option[Iat], Option[Sub],Option[Jti],String)},
+    * This method uses the underlying method {@link #validateEncodedJwtWithEncodedSecret(String,Array[Byte],Algorithm,Set[HeaderField],Set[ClaimField],Set[String],Set[String],Option[Iss],Option[Aud], Option[Iat], Option[Sub],Option[Jti],String)},
     * by providing the secret with {@link String#getBytes(StandardCharsets#UTF_8)}
     */
   def validateEncodedJwt(
@@ -139,7 +139,20 @@ object DecodedJwt {
                           sub: Option[Sub] = None,
                           jti: Option[Jti] = None,
                           charset: String = "UTF-8"): Try[Jwt] = {
-    validateEncodedJwtWithEncodedSecret(jwt, key.getBytes(UTF_8), requiredAlg, requiredHeaders, requiredClaims, ignoredHeaders, ignoredClaims, iss, aud, iat, sub, jti, charset)
+    validateEncodedJwtWithEncodedSecret(
+                                        jwt,
+                                        key.getBytes(UTF_8),
+                                        requiredAlg,
+                                        requiredHeaders,
+                                        requiredClaims,
+                                        ignoredHeaders,
+                                        ignoredClaims,
+                                        iss,
+                                        aud,
+                                        iat,
+                                        sub,
+                                        jti,
+                                        charset)
   }
 
   /**

--- a/src/test/scala/io/igl/jwt/JwtSpec.scala
+++ b/src/test/scala/io/igl/jwt/JwtSpec.scala
@@ -1,6 +1,7 @@
 package io.igl.jwt
 
-import io.igl.jwt.Algorithm.{HS512, HS384}
+import io.igl.jwt.Algorithm.{HS384, HS512}
+import org.apache.commons.codec.binary.Base64
 import play.api.libs.json.{JsNumber, JsValue}
 
 import scala.util.Success
@@ -423,4 +424,21 @@ class JwtSpec extends UnitSpec {
     ).isFailure should be (true)
   }
 
+  it should "support Base64 Encoded Secret" in {
+    val decoder = new Base64(true)
+    val alg = Alg(Algorithm.HS256)
+    val jwt = new DecodedJwt(Seq(alg, Typ("JWT")), Seq(Iss("foo")))
+    val decodedSecret:Array[Byte] = decoder.decode(secret)
+    val encoded = jwt.encodedAndSigned(decodedSecret)
+
+   encoded should be ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmb28ifQ.M-3mD1aZMseTJW_lnV2_YKuMXcMKIBVevaSYLU4P3zE")
+
+    DecodedJwt.validateEncodedJwtWithEncodedSecret(
+      encoded,
+      decodedSecret,
+      alg.value,
+      Set(Typ),
+      Set(Iss)
+    ) should be (Success(jwt))
+  }
 }

--- a/src/test/scala/io/igl/jwt/JwtSpec.scala
+++ b/src/test/scala/io/igl/jwt/JwtSpec.scala
@@ -428,7 +428,7 @@ class JwtSpec extends UnitSpec {
     val decoder = new Base64(true)
     val alg = Alg(Algorithm.HS256)
     val jwt = new DecodedJwt(Seq(alg, Typ("JWT")), Seq(Iss("foo")))
-    val decodedSecret:Array[Byte] = decoder.decode(secret)
+    val decodedSecret : Array[Byte] = decoder.decode(secret)
     val encoded = jwt.encodedAndSigned(decodedSecret)
 
    encoded should be ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmb28ifQ.M-3mD1aZMseTJW_lnV2_YKuMXcMKIBVevaSYLU4P3zE")


### PR DESCRIPTION
Hi, we are trying to use Auth0 with your library and it was not working.  

After investigation we found out that the secret key provided by Auth0 is Base64 Url encoded.  Since the public methods only accept a String as a Secret key that is converted to an Array of byte when verifying the signature. 
I'm proposing to add public method to provide the secret as an Array of Byte in a similar manner than the java Auth0 library( https://github.com/auth0/java-jwt/blob/master/src/main/java/com/auth0/jwt/JWTVerifier.java ).
