### PR TITLE
Upgrade Play-JSON, Scala and SBT versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
+# by default Travis uses JDK 8u31, which is much too old for Scala 2.12 (versions before 8u102 have issues - https://issues.scala-lang.org/browse/SI-9828)
+# Trusty uses JDK 8u131
+dist: trusty
+sudo: false
+
 language: scala
+
 scala:
-   - 2.11.7
+  - 2.12.3
+  - 2.11.11
+
 jdk:
    - oraclejdk8
+
+script: sbt ++$TRAVIS_SCALA_VERSION clean test
    

--- a/build.sbt
+++ b/build.sbt
@@ -10,16 +10,10 @@ scalaVersion := "2.12.3"
 crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 libraryDependencies ++= Seq(
-  playjson(scalaVersion.value),
+  "com.typesafe.play" %% "play-json" % "2.6.3",
   "commons-codec" % "commons-codec" % "1.10",
   scalatest(scalaVersion.value)
 )
-
-def playjson(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-  case Some((2, 11)) => "com.typesafe.play" %% "play-json" % "2.4.0"
-  case Some((2, 12)) => "com.typesafe.play" %% "play-json" % "2.6.3"
-  case _ => sys.error("Unknown Scala version")
-}
 
 def scalatest(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
   case Some((2, 11)) => "org.scalatest" % "scalatest_2.11" % "2.2.4" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,8 @@ crossScalaVersions := Seq("2.11.11", "2.12.3")
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.6.3",
   "commons-codec" % "commons-codec" % "1.10",
-  scalatest(scalaVersion.value)
+  "org.scalatest" %% "scalatest" % "3.0.1" % Test
 )
-
-def scalatest(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-  case Some((2, 11)) => "org.scalatest" % "scalatest_2.11" % "2.2.4" % Test
-  case Some((2, 12)) => "org.scalatest" % "scalatest_2.12" % "3.0.1" % Test
-  case _ => sys.error("Unknown Scala version")
-}
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,13 @@
+import sbt.Keys.scalaVersion
+
 name := "jwt"
 
 organization := "io.igl"
 
 version := "1.2.2"
 
-scalaVersion := "2.12.1"
-crossScalaVersions := Seq("2.11.7", "2.12.1")
+scalaVersion := "2.12.3"
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 libraryDependencies ++= Seq(
   playjson(scalaVersion.value),
@@ -13,14 +15,16 @@ libraryDependencies ++= Seq(
   scalatest(scalaVersion.value)
 )
 
-def playjson(scalaVersion: String) = scalaVersion match {
-  case "2.12.1" => "com.typesafe.play" %% "play-json" % "2.6.0-M6"
-  case "2.11.7" => "com.typesafe.play" %% "play-json" % "2.4.0"
+def playjson(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
+  case Some((2, 11)) => "com.typesafe.play" %% "play-json" % "2.4.0"
+  case Some((2, 12)) => "com.typesafe.play" %% "play-json" % "2.6.3"
+  case _ => sys.error("Unknown Scala version")
 }
 
-def scalatest(scalaVersion: String) = scalaVersion match {
-  case "2.12.1" => "org.scalatest" % "scalatest_2.12" % "3.0.1" % "test"
-  case "2.11.7" => "org.scalatest" % "scalatest_2.11" % "2.2.4" % "test"
+def scalatest(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
+  case Some((2, 11)) => "org.scalatest" % "scalatest_2.11" % "2.2.4" % Test
+  case Some((2, 12)) => "org.scalatest" % "scalatest_2.12" % "3.0.1" % Test
+  case _ => sys.error("Unknown Scala version")
 }
 
 publishMavenStyle := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16


### PR DESCRIPTION
https://travis-ci.org/mr-git/jwt/builds/267284892 - cross build results on Travis
Play-JSON 2.6.3 and Scalatest 3.0.1 both have support for both Scala 2.11 and 2.12