### PR TITLE
Updated constantTimeIsEqual to use binary addition to address a possible issue of summing up negative and positive sub-results of XOR operations to `0`.

### DIFF
--- a/src/main/scala/io/igl/jwt/DecodedJwt.scala
+++ b/src/main/scala/io/igl/jwt/DecodedJwt.scala
@@ -129,7 +129,7 @@ object DecodedJwt {
 
   private def constantTimeIsEqual(as: Array[Byte], bs: Array[Byte]): Boolean = {
     as.length == bs.length match {
-      case true => (as zip bs).foldLeft (0) {(r, ab) => r + (ab._1 ^ ab._2)} == 0
+      case true => (as zip bs).foldLeft (0) {(r, ab) => r | (ab._1 ^ ab._2)} == 0
       case _ => false
     }
   }


### PR DESCRIPTION
Related to #1 

I think the current implementation of `constantTimeIsEqual` might have an issue:

The ` r + (ab._1 ^ ab._2)` part is not exactly the same as `result |= a[i] ^ b[i]` from the [article](http://codahale.com/a-lesson-in-timing-attacks/), as it uses addition of signed bytes as opposed to binary addition (OR), where sign does not matter.
So it is possible to get say a `1` and a `-1` via XORing and then add them up to a `0`. `Array(-3,-2,4,1).sum` is also 0, but `Array(-3,-2,4,1).foldLeft(0){ (r,n) => r | n }` is not. Hope this illustrates the point.

---

PS. Just noticed deprecation warning. Keeping PR open for anyone who wants to use/fork the library.
